### PR TITLE
Allows for correct handling of Seurat objects that have a non-default number of PCs used in dimensionality reduction.

### DIFF
--- a/R/doubletFinder.R
+++ b/R/doubletFinder.R
@@ -57,7 +57,7 @@ doubletFinder <- function(seu, expected.doublets = 0, proportion.artificial = 0.
   print("Scaling data...")
   seu_wdoublets <- Seurat::ScaleData(seu_wdoublets, display.progress = TRUE)
   print("Running PCA...")
-  seu_wdoublets <- Seurat::RunPCA(seu_wdoublets, pc.genes = seu_wdoublets@var.genes, pcs.print = 0)
+  seu_wdoublets <- Seurat::RunPCA(seu_wdoublets, pcs.compute=ncol(seu@dr$pca@cell.embeddings), pc.genes = seu_wdoublets@var.genes, pcs.print = 0)
   
   ## Step 3: Record cell names and number
   cell.names <- seu_wdoublets@cell.names


### PR DESCRIPTION
Thanks very much for developing DoubletFinder! I was just testing it out on a dataset on my own and I noticed that the RunPCA call doesn't specify the number of PCs to compute on the combined object with both simulated doublets and original data. This means that if the user (like me) used something more than the default number of PCs as input to tSNE, then you get an out of bounds error (as this set of PCs is used to access the PCs from the new object). This just makes it compute the same number of PCs as in the original object.

Thanks again!
Andrew