### PR TITLE
Added a small error detector to paramSweep

### DIFF
--- a/R/paramSweep_v3.R
+++ b/R/paramSweep_v3.R
@@ -111,6 +111,7 @@ paramSweep_v3 <- function(seu, PCs, sct = FALSE) {
     for (k in 1:length(pK)) {
       print(paste("pK = ", pK[k], "...", sep = ""))
       pk.temp <- round(nCells * pK[k])
+      if(pk.temp==0){stop("pk.temp is zero. Either increase the number of cells in the dataset (to over 2000) or increase the minimum value of pK tested")}
       pANN <- as.data.frame(matrix(0L, nrow = n.real.cells, ncol = 1))
       colnames(pANN) <- "pANN"
       rownames(pANN) <- real.cells


### PR DESCRIPTION
If pk.temp == 0 then the output values are NaN. ParamSweep completes fine but then summarizeSweep crashes. Better way of handling this would be to drop values of pK which are not compatable with so few cells, but for now this at least let's it fail gracefully. This bug only really occurs during testing (if less than 2000 cells are used)... but I can imagine quite a few users might try running initially on dummy datasets.