### PR TITLE
With sct=TRUE the function crashes if you set PCs

### DIFF
--- a/R/paramSweep_v3.R
+++ b/R/paramSweep_v3.R
@@ -85,7 +85,7 @@ paramSweep_v3 <- function(seu, PCs, sct = FALSE) {
       seu_wdoublets <- SCTransform(seu_wdoublets)
 
       print("Running PCA...")
-      seu_wdoublets <- RunPCA(seu_wdoublets)
+      seu_wdoublets <- RunPCA(seu_wdoublets, npcs = length(PCs))
     }
 
     ## Compute PC distance matrix


### PR DESCRIPTION
To avoid errors, RunPCA needs to be told how many dimensions to use

Apologies for bombarding you with changes today!