### PR TITLE
Doublets by type

### DIFF
--- a/man/doubletFinder_v3.Rd
+++ b/man/doubletFinder_v3.Rd
@@ -5,7 +5,7 @@
 Core doublet prediction function of the DoubletFinder package. Generates artifical doublets from an existing, pre-processed Seurat object. Real and artificial data are then merged and pre-processed using parameters utilized for the existing Seurat object. PC distance matrix is then computed and used the measure the proportion of artificial nearest neighbors (pANN) for every real cell. pANN is then thresholded according to the number of expected doublets to generate final doublet predictions.
 }
 \usage{
-doubletFinder_V3(seu, PCs, pN = 0.25, pK, nExp, reuse.pANN = FALSE, sct = FALSE)
+doubletFinder_V3(seu, PCs, pN = 0.25, pK, nExp, reuse.pANN = FALSE, sct = FALSE, annotations = NULL)
 }
 \arguments{
   \item{seu}{ A fully-processed Seurat object (i.e., After NormalizeData, FindVariableGenes, ScaleData, and RunPCA have all been performed).
@@ -21,6 +21,8 @@ doubletFinder_V3(seu, PCs, pN = 0.25, pK, nExp, reuse.pANN = FALSE, sct = FALSE)
   \item{reuse.pANN}{ Seurat metadata column name for previously-generated pANN results. Argument should be set to FALSE (default) for initial DoubletFinder runs. Enables fast adjusting of doublet predictions for different nExp.
   }
   \item{sct}{ Logical representing whether SCTransform was used during original Seurat object pre-processing (default = FALSE).
+  }
+  \item{annotations}{Optional character vector of cell type annotations. If provided, this function will keep track of the type of each artificial doublet and will yield guesses for what types were combined to form each doublet that is called. (default = NULL).
   }
 }
 \details{

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(DoubletFinder)
+
+test_check("DoubletFinder")

--- a/tests/testthat/test-doubletFinder_v3.R
+++ b/tests/testthat/test-doubletFinder_v3.R
@@ -1,0 +1,25 @@
+test_that("doubletFinder_v3 works", {
+  library("Seurat")
+  # Make test deterministic
+  set.seed(0)
+  # Err if wrong length, type, or if any missingness
+  testthat::expect_error(
+    doubletFinder_v3(pbmc_small, PCs = 1:4, pN = 0.25, pK = 0.01, nExp = 5, reuse.pANN = FALSE, sct=FALSE,
+                     annotations = "blah")
+  )
+  testthat::expect_error(
+    doubletFinder_v3(pbmc_small, PCs = 1:4, pN = 0.25, pK = 0.01, nExp = 5, reuse.pANN = FALSE, sct=FALSE,
+                     annotations = as.factor(pbmc_small$RNA_snn_res.1))
+  )
+  testthat::expect_error(
+    doubletFinder_v3(pbmc_small, PCs = 1:4, pN = 0.25, pK = 0.01, nExp = 5, reuse.pANN = FALSE, sct=FALSE,
+                     annotations = as.character(NA*as.numeric(pbmc_small$RNA_snn_res.1)))
+  )
+  testthat::expect_output(
+    pbmc_small_dubs <- doubletFinder_v3(pbmc_small, PCs = 1:4, pN = 0.25, pK = 0.01, nExp = 5, reuse.pANN = FALSE, sct=FALSE,
+                                        annotations = as.character(pbmc_small$RNA_snn_res.1))
+  )
+  testthat::expect_length( pbmc_small_dubs$DF.doublet.contributors_0.25_0.01_5_0, 80 )
+  testthat::expect_length( pbmc_small_dubs$DF.doublet.contributors_0.25_0.01_5_1, 80 )
+  testthat::expect_length( pbmc_small_dubs$DF.doublet.contributors_0.25_0.01_5_2, 80 )
+})


### PR DESCRIPTION
Hi Dr. McGinnis, this pull request adds the feature discussed in #127 , along with docs and a unit test. Two details worth noting: 

- in a dataset with k cell types, there are (k+1) * k / 2 types of doublets, including homotypic, but so far this feature is set up in a simpler way so that it yields only k features as output. If the nearest neighbors of a cell include a doublet with cell types k1 and k2, then the counts for k1 and k2 are separately incremented.
- the names of the output columns have parameters appended just as you've done with the classification and pANN score. 