### PR TITLE
Fix error with annotations of the types of the doublets

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,3 +9,7 @@ Description: DoubletFinder identifies doublets by generating artificial doublets
 License: CC-0
 Encoding: UTF-8
 LazyData: true
+Suggests: 
+    testthat (>= 3.0.0)
+Config/testthat/edition: 3
+RoxygenNote: 7.1.2

--- a/R/doubletFinder_v3.R
+++ b/R/doubletFinder_v3.R
@@ -113,14 +113,23 @@ doubletFinder_v3 <- function(seu, PCs, pN = 0.25, pK, nExp, reuse.pANN = FALSE, 
     k <- round(nCells * pK)
     for (i in 1:n_real.cells) {
       neighbors <- order(dist.mat[, i])
+      cat("i: ", i, "\n")
+      cat(neighbors, "\n")
       neighbors <- neighbors[2:(k + 1)]
       pANN$pANN[i] <- length(which(neighbors > n_real.cells))/k
       if(!is.null(annotations)){
         for(ct in unique(annotations)){
-          neighbor_types[i,] <- 
-            table( doublet_types1[neighbors - n_real.cells] ) +
-            table( doublet_types2[neighbors - n_real.cells] )
-          neighbor_types[i,] <- neighbor_types[i,] / sum( neighbor_types[i,] )
+          cat(neighbors, "\n")
+          cat(n_real.cells, "\n")
+          neighbors_that_are_doublets = neighbors[neighbors>n_real.cells]
+          if(length(neighbors_that_are_doublets) > 0){
+            neighbor_types[i,] <-
+              table( doublet_types1[neighbors_that_are_doublets - n_real.cells] ) +
+              table( doublet_types2[neighbors_that_are_doublets - n_real.cells] )
+            neighbor_types[i,] <- neighbor_types[i,] / sum( neighbor_types[i,] )
+          } else {
+            neighbor_types[i,] <- NA
+          }
         }
       }
     }
@@ -133,7 +142,7 @@ doubletFinder_v3 <- function(seu, PCs, pN = 0.25, pK, nExp, reuse.pANN = FALSE, 
     if(!is.null(annotations)){
       colnames(neighbor_types) = levels(doublet_types1)
       for(ct in levels(doublet_types1)){
-        seu@meta.data[, paste("DF.doublet.contributors",pN,pK,nExp,ct,sep="_")] <- neighbor_types[,ct] 
+        seu@meta.data[, paste("DF.doublet.contributors",pN,pK,nExp,ct,sep="_")] <- neighbor_types[,ct]
       }
     }
     return(seu)

--- a/R/doubletFinder_v3.R
+++ b/R/doubletFinder_v3.R
@@ -113,14 +113,10 @@ doubletFinder_v3 <- function(seu, PCs, pN = 0.25, pK, nExp, reuse.pANN = FALSE, 
     k <- round(nCells * pK)
     for (i in 1:n_real.cells) {
       neighbors <- order(dist.mat[, i])
-      cat("i: ", i, "\n")
-      cat(neighbors, "\n")
       neighbors <- neighbors[2:(k + 1)]
       pANN$pANN[i] <- length(which(neighbors > n_real.cells))/k
       if(!is.null(annotations)){
         for(ct in unique(annotations)){
-          cat(neighbors, "\n")
-          cat(n_real.cells, "\n")
           neighbors_that_are_doublets = neighbors[neighbors>n_real.cells]
           if(length(neighbors_that_are_doublets) > 0){
             neighbor_types[i,] <-

--- a/R/doubletFinder_v3.R
+++ b/R/doubletFinder_v3.R
@@ -129,7 +129,6 @@ doubletFinder_v3 <- function(seu, PCs, pN = 0.25, pK, nExp, reuse.pANN = FALSE, 
         }
       }
     }
-
     print("Classifying doublets..")
     classifications <- rep("Singlet",n_real.cells)
     classifications[order(pANN$pANN[1:n_real.cells], decreasing=TRUE)[1:nExp]] <- "Doublet"

--- a/man/doubletFinder_v3.Rd
+++ b/man/doubletFinder_v3.Rd
@@ -22,7 +22,7 @@ doubletFinder_V3(seu, PCs, pN = 0.25, pK, nExp, reuse.pANN = FALSE, sct = FALSE,
   }
   \item{sct}{ Logical representing whether SCTransform was used during original Seurat object pre-processing (default = FALSE).
   }
-  \item{annotations}{Optional character vector of cell type annotations. If provided, this function will keep track of the type of each artificial doublet and will yield guesses for what types were combined to form each doublet that is called. (default = NULL).
+  \item{annotations}{Optional character vector of cell type annotations. If provided, this function will keep track of the type of each artificial doublet and will yield guesses for constituent cell types. Specifically, it returns the proportion of different constituent cell types across all the artificial doublets that each cell is similar to. (default = NULL). For cells with no artificial doublet neighbors, the guesses will be NA.
   }
 }
 \details{

--- a/tests/testthat/test-doubletFinder_v3.R
+++ b/tests/testthat/test-doubletFinder_v3.R
@@ -19,7 +19,11 @@ test_that("doubletFinder_v3 works", {
     pbmc_small_dubs <- doubletFinder_v3(pbmc_small, PCs = 1:4, pN = 0.25, pK = 0.01, nExp = 5, reuse.pANN = FALSE, sct=FALSE,
                                         annotations = as.character(pbmc_small$RNA_snn_res.1))
   )
-  testthat::expect_length( pbmc_small_dubs$DF.doublet.contributors_0.25_0.01_5_0, 80 )
-  testthat::expect_length( pbmc_small_dubs$DF.doublet.contributors_0.25_0.01_5_1, 80 )
-  testthat::expect_length( pbmc_small_dubs$DF.doublet.contributors_0.25_0.01_5_2, 80 )
+  testthat::expect_output(
+    pbmc_small_dubs <- doubletFinder_v3(pbmc_small, PCs = 1:4, pN = 0.5, pK = 0.01, nExp = 5, reuse.pANN = FALSE, sct=FALSE,
+                                        annotations = as.character(pbmc_small$RNA_snn_res.1))
+  )
+  testthat::expect_length( pbmc_small_dubs$DF.doublet.contributors_0.5_0.01_5_0, 80 )
+  testthat::expect_length( pbmc_small_dubs$DF.doublet.contributors_0.5_0.01_5_1, 80 )
+  testthat::expect_length( pbmc_small_dubs$DF.doublet.contributors_0.5_0.01_5_2, 80 )
 })


### PR DESCRIPTION
This is related to #133 . We thought it was resolved, but the ekernf01 fork and the original repo are giving different results. I am hoping this merge will bring them in line and fully resolve the issue. 