### PR TITLE
Support for BPCells

### DIFF
--- a/R/doubletFinder.R
+++ b/R/doubletFinder.R
@@ -86,7 +86,14 @@ doubletFinder <- function(seu,
     print(paste("Creating",n_doublets,"artificial doublets...",sep=" "))
     real.cells1 <- sample(real.cells, n_doublets, replace = TRUE)
     real.cells2 <- sample(real.cells, n_doublets, replace = TRUE)
-    doublets <- (data[, real.cells1] + data[, real.cells2])/2
+    if(inherits(data,what = "IterableMatrix")){
+      doublets <- ((as(data[, unique(real.cells1)],"dgCMatrix")[,real.cells1] +
+                 as(data[, unique(real.cells2)],"dgCMatrix")[,real.cells2])/2) |>
+                as("IterableMatrix") |>
+                write_matrix_dir(tempfile())
+		} else {
+      doublets <- (data[, real.cells1] + data[, real.cells2])/2
+      }
     colnames(doublets) <- paste("X", 1:n_doublets, sep = "")
     data_wdoublets <- cbind(data, doublets)
     # Keep track of the types of the simulated doublets

--- a/R/parallel_paramSweep.R
+++ b/R/parallel_paramSweep.R
@@ -41,7 +41,14 @@ parallel_paramSweep <- function(n, n.real.cells,
   n_doublets <- round(n.real.cells/(1 - pN[n]) - n.real.cells)
   real.cells1 <- sample(real.cells, n_doublets, replace = TRUE)
   real.cells2 <- sample(real.cells, n_doublets, replace = TRUE)
-  doublets <- (data[, real.cells1] + data[, real.cells2])/2
+  if(inherits(data,what = "IterableMatrix")){
+      doublets <- ((as(data[, unique(real.cells1)],"dgCMatrix")[,real.cells1] +
+                 as(data[, unique(real.cells2)],"dgCMatrix")[,real.cells2])/2) |>
+                as("IterableMatrix") |>
+                write_matrix_dir(tempfile())
+		} else {
+      doublets <- (data[, real.cells1] + data[, real.cells2])/2
+      }
   colnames(doublets) <- paste("X", 1:n_doublets, sep = "")
   data_wdoublets <- cbind(data, doublets)
 


### PR DESCRIPTION
This should resolve #183.
`real.cells1 <- sample(real.cells, n_doublets, replace = TRUE)` Sampling with replacement results in duplicates. BPCells `IterableMatrix` does not allow selection from a list that contains duplicates. The workaround is to select unique cells from the list, load into memory by converting to `dgCMatrix`, before selecting from the list again. This will load the minimum number of cells to memory. The matrix is converted back to `IterableMatrix` and saved to disk in temp folder. 